### PR TITLE
update tags and date format

### DIFF
--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -206,7 +206,7 @@ export function subscribeToDocumentChanges(
 
 function testSigmaTags(rule: any, doc: vscode.TextDocument): vscode.Diagnostic[] | undefined {
     try {
-        var tagsPattern = /cve\.\d+\.\d+|attack\.t\d+\.*\d*|attack\.[a-z_]+|car\.\d{4}-\d{2}-\d{3}|tlp\.|detection\.|stp\./
+        var tagsPattern = /cve\.\d+\-\d+|attack\.t\d+\.*\d*|attack\.[a-z_]+|car\.\d{4}-\d{2}-\d{3}|tlp\.(red|amber(\+strict)?|green|clear)|detection\.(dfir|threat-hunting|emerging-threats)|stp\./
         let knowntags: string[] = []
         var diagnostics = rule.tags
             .map((tag: string) => {

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -398,7 +398,7 @@ function testMeta(rule: any, doc: vscode.TextDocument): vscode.Diagnostic[] | un
             }
         }
         // Check Related Field
-        let validRelType = ["derived", "obsoletes", "merged", "renamed", "similar"]
+        let validRelType = ["derived", "obsolete", "merged", "renamed", "similar"]
         if (rule.related) {
             if (!Array.isArray(rule.related)) {
                 var range = getRangeOfString("related:", doc)
@@ -415,7 +415,7 @@ function testMeta(rule: any, doc: vscode.TextDocument): vscode.Diagnostic[] | un
                             diagnostics.push(
                                 new vscode.Diagnostic(
                                     range,
-                                    "Unknown Related Type - Allowed: derived, obsoletes, merged, renamed, similar",
+                                    "Unknown Related Type - Allowed: derived, obsolete, merged, renamed, similar",
                                     vscode.DiagnosticSeverity.Warning,
                                 ),
                             )

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -206,7 +206,7 @@ export function subscribeToDocumentChanges(
 
 function testSigmaTags(rule: any, doc: vscode.TextDocument): vscode.Diagnostic[] | undefined {
     try {
-        var tagsPattern = /cve\.\d+\-\d+|attack\.t\d+\.*\d*|attack\.[a-z_]+|car\.\d{4}-\d{2}-\d{3}|tlp\.(red|amber(\+strict)?|green|clear)|detection\.(dfir|threat-hunting|emerging-threats)|stp\./
+        var tagsPattern = /cve\.\d+\-\d+|attack\.t\d+\.*\d*|attack\.[a-z_]+|car\.\d{4}-\d{2}-\d{3}|tlp\.(red|amber(\-strict)?|green|clear)|detection\.(dfir|threat-hunting|emerging-threats)|stp\./
         let knowntags: string[] = []
         var diagnostics = rule.tags
             .map((tag: string) => {

--- a/src/snippetProvider.ts
+++ b/src/snippetProvider.ts
@@ -87,9 +87,9 @@ function generateTodaySnippet(
         console.log("SigmaSnippetCompletionItemProvider: Generating 'today' snippet")
     }
     snippet.appendVariable("CURRENT_YEAR", "Unknown Year")
-    snippet.appendText("/")
+    snippet.appendText("-")
     snippet.appendVariable("CURRENT_MONTH", "Unknown Month")
-    snippet.appendText("/")
+    snippet.appendText("-")
     snippet.appendVariable("CURRENT_DATE", "Unknown Date")
     return snippet
 }

--- a/src/snippetProvider.ts
+++ b/src/snippetProvider.ts
@@ -28,7 +28,7 @@ function generateRelatedSnippet(
     snippet.appendText("related:\n")
     snippet.appendText("\t- id: \n")
     snippet.appendText("\t  type: ")
-    snippet.appendChoice(['derived', 'merged', 'obsoletes', 'renamed', 'similar'])
+    snippet.appendChoice(['derived', 'merged', 'obsolete', 'renamed', 'similar'])
     return snippet
 }
 


### PR DESCRIPTION
This PR updates the tags for the detection and cve namespaces.

In V2 of the spec, both the dates (date & modified) and tags fields uses `-` instead of `/`. So the following changes were made:

- Update the `generateTodaySnippet` function to use `-` instead of `/`
- Update the related type from `obsoletes` to `obsolete`
- Update the `tagsPattern` for the following:
  - The `cve` will use `-` instead of `/`
  - Added all current possible values for TLP namespace
  - Added all current possible values for detection namespace